### PR TITLE
Add support for url-template keys

### DIFF
--- a/src/l-tile-layer.js
+++ b/src/l-tile-layer.js
@@ -12,17 +12,38 @@ class LTileLayer extends LLayer {
 
   connectedCallback() {
     const urlTemplate = parse(htmlAttribute("url-template"), this)
+    
+    // Template attributes
+    const urlAttributes = LTileLayer.parseTemplateAttributes(urlTemplate)
+    const templateOptions = {}
+    for (const attribute of urlAttributes) {
+      const value = this.getAttribute(attribute)
+      if (value !== null) {
+        templateOptions[attribute] = value
+      }
+    }
+    
+    // Options
     const name = this.getAttribute("name");
     const schema = partial({
       attribution: optional(htmlAttribute("attribution"))
     })
     const options = parse(schema, this)
-    this.layer = tileLayer(urlTemplate, options);
+    this.layer = tileLayer(urlTemplate, { ...templateOptions, ...options });
     const event = new CustomEvent(mapAddTo, {
       detail: { name, layer: this.layer },
       bubbles: true,
     });
     this.dispatchEvent(event);
+  }
+
+  /**
+   * @param {string} urlTemplate
+   * @returns {string[]}
+   */
+  static parseTemplateAttributes(urlTemplate) {
+    const regex = /{(.*?)}/g
+    return [...urlTemplate.matchAll(regex)].map(match => match[1])
   }
 }
 

--- a/src/l-tile-layer.test.js
+++ b/src/l-tile-layer.test.js
@@ -23,3 +23,15 @@ it("should cover l-tile-layer", async () => {
   };
   expect(actual).toEqual(expected);
 });
+
+it("should perform arbitrary templating", () => {
+  const urlTemplate = "/tile/{z}/{x}/{y}.png?key={key}";
+  const el = document.createElement("l-tile-layer");
+  el.setAttribute("url-template", urlTemplate);
+  el.setAttribute("key", "value")
+  document.body.appendChild(el);
+
+  const actual = el.layer
+  const expected = tileLayer(urlTemplate, { key: "value" })
+  expect(actual).toEqual(expected)
+})

--- a/src/l-tile-layer.test.js
+++ b/src/l-tile-layer.test.js
@@ -24,14 +24,17 @@ it("should cover l-tile-layer", async () => {
   expect(actual).toEqual(expected);
 });
 
-it("should perform arbitrary templating", () => {
-  const urlTemplate = "/tile/{z}/{x}/{y}.png?key={key}";
+it.each([
+  ["/tile/{z}/{x}/{y}.png?key={key}", "key", "value"],
+  ["/tile/{z}/{x}/{y}.png?key={camelCase}", "camelCase", "value"],
+  ["/tile/{z}/{x}/{y}.png?key={kebab-case}", "kebab-case", "value"]
+])("should perform arbitrary templating %s %s", (urlTemplate, key, value) => {
   const el = document.createElement("l-tile-layer");
   el.setAttribute("url-template", urlTemplate);
-  el.setAttribute("key", "value")
+  el.setAttribute(key, value)
   document.body.appendChild(el);
 
   const actual = el.layer
-  const expected = tileLayer(urlTemplate, { key: "value" })
+  const expected = tileLayer(urlTemplate, { [key]: value })
   expect(actual).toEqual(expected)
 })


### PR DESCRIPTION
Add the ability to use arbitrary `key`, `value` pairs in a `url-template`.

```html
<l-tile-layer url-template="https...?key={apikey}" apikey="123ABC="></l-tile-layer>
```

https://leafletjs.com/reference.html#tilelayer

**Note** Attributes are case-insensitive, so a template variable `...png?v={apiKey}` could be specified in HTML as `<l-tile-layer ... apikey="..."` or `<l-tile-layer ... APIKey="..."` etc.
