### PR TITLE
Add error-tile-url to l-tile-layer element

### DIFF
--- a/src/l-tile-layer.js
+++ b/src/l-tile-layer.js
@@ -26,7 +26,8 @@ class LTileLayer extends LLayer {
     // Options
     const name = this.getAttribute("name");
     const schema = partial({
-      attribution: optional(htmlAttribute("attribution"))
+      attribution: optional(htmlAttribute("attribution")),
+      errorTileUrl: optional(htmlAttribute("error-tile-url"))
     })
     const options = parse(schema, this)
     this.layer = tileLayer(urlTemplate, { ...templateOptions, ...options });

--- a/src/l-tile-layer.test.js
+++ b/src/l-tile-layer.test.js
@@ -38,3 +38,16 @@ it.each([
   const expected = tileLayer(urlTemplate, { [key]: value })
   expect(actual).toEqual(expected)
 })
+
+it("should support error-tile-url", () => {
+  const urlTemplate = "/{z}/{x}/{y}.png"
+  const errorTileUrl = "/error.png"
+  const el = document.createElement("l-tile-layer");
+  el.setAttribute("url-template", urlTemplate);
+  el.setAttribute("error-tile-url", errorTileUrl)
+  document.body.appendChild(el);
+
+  const actual = el.layer
+  const expected = tileLayer(urlTemplate, { errorTileUrl })
+  expect(actual).toEqual(expected)
+})


### PR DESCRIPTION
### Add an optional HTML attribute to support errorTileUrl

Quickly added a useful attribute to `<l-tile-layer>` custom element.

```html
<l-tile-layer error-tile-url="http://.../error.png" ...></l-tile-layer>
```