### PR TITLE
Add layer removal to disconnected callback in image overlay

### DIFF
--- a/src/l-image-overlay.js
+++ b/src/l-image-overlay.js
@@ -39,7 +39,7 @@ class LImageOverlay extends LLayer {
   }
 
   disconnectedCallback() {
-    this.layer.remove();
+    this.layer?.remove();
   }
 
   attributeChangedCallback(name, _oldValue, newValue) {

--- a/src/l-image-overlay.js
+++ b/src/l-image-overlay.js
@@ -38,6 +38,10 @@ class LImageOverlay extends LLayer {
     );
   }
 
+  disconnectedCallback() {
+    this.layer.remove();
+  }
+
   attributeChangedCallback(name, _oldValue, newValue) {
     if (this.layer !== null) {
       if (name === "url") {


### PR DESCRIPTION
This change introduces the ability to remove an image overlay layer from the map when the html element is disconnected from the DOM.