### PR TITLE
Add zoom-control boolean attribute to l-map html element

### DIFF
--- a/src/l-map.js
+++ b/src/l-map.js
@@ -5,7 +5,7 @@ import LLayer from "./l-layer.js";
 import { distribute, int, json, option, parse } from "./parse.js";
 
 class LMap extends HTMLElement {
-  static observedAttributes = ["zoom", "center"];
+  static observedAttributes = ["zoom", "center", "zoom-control"];
 
   constructor() {
     super();
@@ -37,7 +37,7 @@ class LMap extends HTMLElement {
   }
 
   connectedCallback() {
-    this.map = L.map(this);
+    this.map = L.map(this, { zoomControl: this.hasAttribute("zoom-control") });
 
     // Allow listeners to know when the map is "ready"
     this.map.whenReady(() => {


### PR DESCRIPTION
This change adds a zoom-control boolean attribute to the l-map html element. 

Note that by default this is set to true, but with this change, the default will be false instead.