### PR TITLE
Add tooltip connected listener to marker

### DIFF
--- a/src/l-marker.js
+++ b/src/l-marker.js
@@ -1,5 +1,5 @@
 import * as L from "leaflet";
-import { layerConnected, popupConnected, iconConnected } from "./events.js";
+import { layerConnected, popupConnected, iconConnected, tooltipConnected } from "./events.js";
 import LLayer from "./l-layer.js";
 import {
   chain,
@@ -22,6 +22,10 @@ class LMarker extends LLayer {
     this.addEventListener(iconConnected, (ev) => {
       ev.stopPropagation();
       this.layer.setIcon(ev.detail.icon);
+    });
+    this.addEventListener(tooltipConnected, (ev) => {
+      ev.stopPropagation();
+      this.layer.bindTooltip(ev.detail.tooltip);
     });
   }
 

--- a/src/l-tooltip.js
+++ b/src/l-tooltip.js
@@ -4,11 +4,14 @@ import { tooltip } from "leaflet";
 import { tooltipConnected } from "./events";
 
 class LTooltip extends HTMLElement {
-  static observedAttributes = ["content"];
+  static observedAttributes = ["content", "permanent", "direction"];
 
   constructor() {
     super();
-    this.tooltip = tooltip();
+    this.tooltip = tooltip({
+      permanent: this.hasAttribute("permanent") ,
+      direction: this.getAttribute("direction")
+    });
   }
 
   connectedCallback() {

--- a/src/l-tooltip.js
+++ b/src/l-tooltip.js
@@ -2,6 +2,7 @@
 
 import { tooltip } from "leaflet";
 import { tooltipConnected } from "./events";
+import { json, option, parse } from "./parse.js";
 
 class LTooltip extends HTMLElement {
   static observedAttributes = ["content", "permanent", "direction"];
@@ -9,8 +10,8 @@ class LTooltip extends HTMLElement {
   constructor() {
     super();
     this.tooltip = tooltip({
-      permanent: this.hasAttribute("permanent") ,
-      direction: this.getAttribute("direction")
+      permanent: this.hasAttribute("permanent"),
+      direction: this.getAttribute("direction") ?? "auto"
     });
   }
 
@@ -19,8 +20,8 @@ class LTooltip extends HTMLElement {
       cancelable: true,
       bubbles: true,
       detail: {
-        tooltip: this.tooltip,
-      },
+        tooltip: this.tooltip
+      }
     });
     this.dispatchEvent(event);
   }


### PR DESCRIPTION
This PR adds a missing tooltip listener to the l-marker and a couple of attributes to the t-tooltip element.