### PR TITLE
Add tests to cover removal from layer group

### DIFF
--- a/src/l-layer-group.test.js
+++ b/src/l-layer-group.test.js
@@ -38,3 +38,29 @@ it("should register layers", async () => {
   };
   expect(actual).toEqual(expected);
 });
+
+it("should support removed layers from a group", async () => {
+  const root = document.createElement("l-layer-group");
+  const marker = document.createElement("l-marker");
+  marker.setAttribute("lat-lng", "[0,0]");
+  root.appendChild(marker);
+  document.body.appendChild(root);
+
+  // System under test
+  marker.remove();
+
+  // Wait one animation frame to allow MutationObserver
+  // to process el.remove()
+  const frame = new Promise((resolve) => {
+    window.requestAnimationFrame(() => {
+      resolve();
+    });
+  });
+  await frame;
+
+  // Assertions
+  const group = root.layer;
+  const actual = group.hasLayer(group.getLayerId(marker.layer));
+  const expected = false;
+  expect(actual).toEqual(expected);
+});


### PR DESCRIPTION
Continuing mission to cover existing functionality in tests to enable future refactoring