### PR TITLE
Add layer removal to disconnect callback for all layers

### DIFF
--- a/src/l-image-overlay.js
+++ b/src/l-image-overlay.js
@@ -45,10 +45,6 @@ class LImageOverlay extends LLayer {
     );
   }
 
-  disconnectedCallback() {
-    this.layer?.remove();
-  }
-
   attributeChangedCallback(name, _oldValue, newValue) {
     if (this.layer !== null) {
       if (name === "url") {

--- a/src/l-layer.js
+++ b/src/l-layer.js
@@ -3,6 +3,10 @@ class LLayer extends HTMLElement {
     super()
     this.layer = null
   }
+
+  disconnectedCallback() {
+    this.layer?.remove();
+  }
 }
 
 export default LLayer


### PR DESCRIPTION
This change is a generalization of a previous change that removed an image overlay from the map when the respective element was disconnected from the DOM. 