### PR TITLE
Extend docs to include api docs

### DIFF
--- a/docs/content/api/_index.md
+++ b/docs/content/api/_index.md
@@ -1,0 +1,5 @@
++++
+title = "API documentation"
+template = "api.html"
+page_template = "api-page.html"
++++

--- a/docs/content/api/l-image-overlay.md
+++ b/docs/content/api/l-image-overlay.md
@@ -1,0 +1,54 @@
++++
+title = "Image overlay"
++++
+
+HTML equivalent to `L.imageOverlay` function.
+Can be a child of `l-map` or `l-layer-group` elements.
+
+## Example
+
+A standard way to initialise an image overlay.
+
+```html
+<l-image-overlay
+  url="/image.png"
+  bounds="[[-1, -1], [1, 1]]"
+></l-image-overlay>
+```
+
+More elaborate example, based on a Leaflet tutorial.
+
+```html
+<l-image-overlay
+  url="https://maps.lib.utexas.edu/maps/historical/newark_nj_1922.jpg"
+  bounds="[[40.799311, -74.118464], [40.68202047785919, -74.33]]"
+  opacity="0.8"
+  interactive="true"
+  error-overlay-url="https://cdn-icons-png.flaticon.com/512/110/110686.png"
+  alt="Image of Newark, N.J. in 1922. Source: The University of Texas at Austin, UT Libraries Map Collection."
+></l-image-overlay>
+```
+
+## Parameters
+
+Mandatory HTML properties to successfully instantiate.
+
+| Attribute | Example | Description |
+| -- | -- | -- |
+| url | /path/to/image.png  | HTTP URL to image |
+| bounds | [[0, 0], [45, 45]] | LatLngBounds to define the image extent |
+
+## Properties
+
+| Attribute | Type | Description |
+| -- | -- | -- |
+| alt | string | Alt text related to image |
+| opacity | float | Value to control transparency |
+
+## Events
+
+| Event key | Detail | Description |
+| -- | -- | -- |
+| l:layer:connected | | Triggered when connected to the document |
+
+

--- a/docs/content/api/l-map.md
+++ b/docs/content/api/l-map.md
@@ -1,0 +1,52 @@
++++
+title = "Map"
++++
+
+HTML equivalent to `L.map` function. Can call methods, e.g. `map.fitWorld()`.
+
+## Example
+
+A standard way to initialise a map is with a center and a zoom level.
+
+```html
+<l-map center="[0,0]" zoom="0"></l-map>
+```
+
+To detect mobile device location, zoom to it and enable location event handlers.
+
+```html
+<l-map fit-world locate='{"setView": true, "maxZoom": 16}' on="locationfound locationerror">
+  ...
+</l-map>
+```
+
+## Parameters
+
+Mandatory HTML properties to successfully instantiate a map.
+
+| Attribute | Example | Description |
+| -- | -- | -- |
+| center | [0, 0]  | LatLng position |
+| zoom | 0 | Zoom level |
+
+OR
+
+| Attribute | Example | Description |
+| -- | -- | -- |
+| fit-world  | | Existence of this property calls `map.fitWorld()` |
+
+## Properties
+
+| Attribute | Value | Description |
+| -- | -- | -- |
+| fit-world | | Auto-fits map to world extent |
+| on | | Used to connect `map.on` Leaflet event handler to HTML CusomEvent |
+| locate | | `map.locate` method call options |
+
+## Events
+
+| Event key | Detail | Description |
+| -- | -- | -- |
+| ready | | Triggered by `map.whenReady` method |
+| l:layer:connected | | Triggered by child elements when a layer is connected to the document |
+

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -25,11 +25,14 @@ body {
   min-height: 100vh;
   display: grid;
   grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr auto;
+  row-gap: 1ch;
 }
 
 h1,
 h2,
-h3 {
+h3,
+th {
   font-family: var(--font-family);
   font-weight: 400;
   font-style: normal;
@@ -108,4 +111,22 @@ footer {
     text-transform: uppercase;
     font-family: var(--font-family);
   }
+}
+
+table {
+  inline-size: 100%;
+  background-color: var(--gray-2);
+  border-radius: var(--size-1);
+  border-collapse: collapse;
+  overflow: hidden;
+}
+
+th {
+  background-color: var(--gray-9);
+  color: var(--gray-1);
+}
+
+td, th {
+  padding: var(--size-2);
+  text-align: left;
 }

--- a/docs/templates/api-page.html
+++ b/docs/templates/api-page.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+  <h1>{{ page.title }}</h1>
+  {{ page.content | safe }}
+</main>
+{% endblock %}

--- a/docs/templates/api.html
+++ b/docs/templates/api.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+  <h1>{{section.title}}</h1>
+  <ul>
+    {% for page in section.pages %}
+      <li><a href="{{ page.permalink | safe }}">{{ page.title }}</a></li>
+    {% endfor %}
+  </ul>
+</main>
+{% endblock content %}

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -36,6 +36,7 @@
 <div>
   <a href="{{ get_url(path='@/_index.md') }}"><iconify-icon icon="mdi:home"></iconify-icon> Home</a>
   <a href="{{ get_url(path='@/articles/_index.md') }}"><iconify-icon icon="material-symbols:article-outline-sharp"></iconify-icon> Articles</a>
+  <a href="{{ get_url(path='@/api/_index.md') }}"><iconify-icon icon="material-symbols:api"></iconify-icon> API</a>
 </div>
 <a href="Https://GitHub.com/andrewgryan/leaflet-html"><iconify-icon icon="mdi:github"></iconify-icon></a>
 </nav>


### PR DESCRIPTION
Add boilerplate, styling and examples of good API docs for leaflet-html