### PR TITLE
Add leaflet event wiring to l-marker element

### DIFF
--- a/docs/content/articles/htmx.md
+++ b/docs/content/articles/htmx.md
@@ -82,4 +82,35 @@ It is just the contents of `<l-map>` that needs careful consideration.
 
 A more elegant mechanism in the future will make it clear which part of the document is controlled by Leaflet.
 
+### Marker as a hypermedia control
 
+```html
+  <l-marker
+    lat-lng="[55,-5]"
+    on="click"
+    hx-trigger="click"
+    hx-target="#placeholder"
+    hx-get="/clicked"></l-marker>
+
+  <div id="placeholder">Hello, World!</div>
+```
+
+<div id="placeholder"><h2>Hello, World!</h2></div>
+
+When the marker is clicked HTMX replaces the content of the above heading.
+
+<l-map center="[55,-5]" zoom="4">
+  <l-tile-layer
+    url-template="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+  ></l-tile-layer>
+<l-marker
+    lat-lng="[55,-5]"
+    on="click"
+    hx-trigger="click"
+    hx-target="#placeholder"
+    hx-get={{ url(path="htmx/clicked.html") }}
+></l-marker>
+</l-map>
+
+Leaflet-HTML connects Leaflet's event system to browser native DOM events.
+HTMX uses browser DOM events to orchestrate network requests and DOM updates.

--- a/src/l-marker-cluster-group.js
+++ b/src/l-marker-cluster-group.js
@@ -1,5 +1,10 @@
 // @ts-check
-import "leaflet.markercluster";
+
+// Make L.markerClusterGroup optional
+import("leaflet.markercluster").catch((error) => {
+  console.warn("Failed to import leaflet.markercluster", error)
+});
+
 import { layerConnected } from "./events.js";
 import LLayer from "./l-layer.js";
 

--- a/src/l-marker.js
+++ b/src/l-marker.js
@@ -1,5 +1,10 @@
 import * as L from "leaflet";
-import { layerConnected, popupConnected, iconConnected, tooltipConnected } from "./events.js";
+import {
+  layerConnected,
+  popupConnected,
+  iconConnected,
+  tooltipConnected,
+} from "./events.js";
 import LLayer from "./l-layer.js";
 import {
   chain,
@@ -19,10 +24,14 @@ class LMarker extends LLayer {
   constructor() {
     super();
     this.layer = null;
+
+    // Icon connected
     this.addEventListener(iconConnected, (ev) => {
       ev.stopPropagation();
       this.layer.setIcon(ev.detail.icon);
     });
+
+    // Tooltip connected
     this.addEventListener(tooltipConnected, (ev) => {
       ev.stopPropagation();
       this.layer.bindTooltip(ev.detail.tooltip);
@@ -50,6 +59,22 @@ class LMarker extends LLayer {
     if (this.hasAttribute("icon")) {
       const icon = L.icon(JSON.parse(this.getAttribute("icon")));
       this.layer.setIcon(icon);
+    }
+
+    // Connect Leaflet events
+    if (this.hasAttribute("on")) {
+      const on = this.getAttribute("on");
+      if (on !== null) {
+        on.split(/\s+/).forEach((eventName) => {
+          if (this.layer !== null) {
+            this.layer.on(eventName, (e) => {
+              this.dispatchEvent(
+                new CustomEvent(eventName, { bubbles: true, detail: e })
+              );
+            });
+          }
+        });
+      }
     }
 
     this.setAttribute("leaflet-id", L.stamp(this.layer));

--- a/src/l-marker.test.js
+++ b/src/l-marker.test.js
@@ -33,3 +33,24 @@ it("changes an icon", () => {
   let expected = L.icon({ iconUrl: "bar.png" });
   expect(actual).toEqual(expected);
 });
+
+it("should register on click handler", async () => {
+  const el = document.createElement("l-marker");
+  el.setAttribute("lat-lng", "[0, 0]");
+  el.setAttribute("on", "click");
+  document.body.appendChild(el);
+  const customEventDetail = new Promise((resolve) => {
+    el.addEventListener("click", (ev) => {
+      resolve(ev.detail);
+    });
+  });
+  const leafletEvent = new Promise((resolve) => {
+    el.layer.on("click", (e) => {
+      resolve(e);
+    });
+  });
+  el.layer.fire("click");
+  const actual = await customEventDetail;
+  const expected = await leafletEvent;
+  expect(actual).toEqual(expected);
+});


### PR DESCRIPTION
Re-use `<l-map on="click">...</l-map>` mechanism to enable connecting Leaflet event system to DOM events.

Also, made `leaflet.markercluster` an optional import.