### PR TITLE
Prevent l-marker events from bubbling

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -13,8 +13,9 @@ export const paneConnected = "l:pane:connected";
 /**
  * @param {HTMLElement} el
  * @param {Evented} evented
+ * @param bubble determines whether events should bubble (defaults to true)
  */
-export const connectLeafletEvents = (el, evented) => {
+export const connectLeafletEvents = (el, evented, bubble = true) => {
   if (el.hasAttribute("on")) {
     const on = el.getAttribute("on");
     if (on !== null) {
@@ -22,7 +23,7 @@ export const connectLeafletEvents = (el, evented) => {
         if (evented !== null) {
           evented.on(eventName, (e) => {
             el.dispatchEvent(
-              new CustomEvent(eventName, { bubbles: true, detail: e })
+              new CustomEvent(eventName, { bubbles: bubble, detail: e })
             );
           });
         }

--- a/src/l-marker.js
+++ b/src/l-marker.js
@@ -63,7 +63,7 @@ class LMarker extends LLayer {
     }
 
     // Connect Leaflet events
-    connectLeafletEvents(this, this.layer);
+    connectLeafletEvents(this, this.layer, false);
 
     this.setAttribute("leaflet-id", L.stamp(this.layer));
 

--- a/src/l-marker.test.js
+++ b/src/l-marker.test.js
@@ -39,9 +39,9 @@ it("should register on click handler", async () => {
   el.setAttribute("lat-lng", "[0, 0]");
   el.setAttribute("on", "click");
   document.body.appendChild(el);
-  const customEventDetail = new Promise((resolve) => {
+  const customEvent = new Promise((resolve) => {
     el.addEventListener("click", (ev) => {
-      resolve(ev.detail);
+      resolve(ev);
     });
   });
   const leafletEvent = new Promise((resolve) => {
@@ -50,7 +50,8 @@ it("should register on click handler", async () => {
     });
   });
   el.layer.fire("click");
-  const actual = await customEventDetail;
+  const actual = await customEvent;
   const expected = await leafletEvent;
-  expect(actual).toEqual(expected);
+  expect(actual.detail).toEqual(expected);
+  expect(actual.bubbles).toEqual(false);
 });


### PR DESCRIPTION
Currently when l-marker elements inside an l-marker-cluster-group are clicked, the cluster appears to try and create a new marker without latlong, which leads to an error. If we set the l-marker event not to bubble up, this issue won't happen.