### PR TITLE
Revert markercluster import to esmodule import statement

### DIFF
--- a/src/l-marker-cluster-group.js
+++ b/src/l-marker-cluster-group.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 // Make L.markerClusterGroup optional
-import("leaflet.markercluster").catch((error) => {
-  console.warn("Failed to import leaflet.markercluster", error)
-});
-
+// import("leaflet.markercluster").catch((error) => {
+//   console.warn("Failed to import leaflet.markercluster", error)
+// });
+import "leaflet.markercluster";
 import { layerConnected } from "./events.js";
 import LLayer from "./l-layer.js";
 


### PR DESCRIPTION
Temporarily revert to `node` environment compatible import statement for marker cluster support.