### PR TITLE
Add pane support to l-tile-layer-wms

### DIFF
--- a/src/l-tile-layer-wms.js
+++ b/src/l-tile-layer-wms.js
@@ -46,9 +46,17 @@ class LTileLayerWMS extends LLayer {
       }
     };
 
+    // Pane options
+    const paneOptions = {}
+    // Support <l-pane> parent element
+    if (this.parentElement.tagName.toLowerCase() === "l-pane") {
+      paneOptions["pane"] = this.parentElement.getAttribute("name")
+    }
+
     this.layer = tileLayer.wms(urlTemplate, {
       ...standardOptions,
       ...nonStandardOptions(),
+      ...paneOptions
     });
     const event = new CustomEvent(layerConnected, {
       detail: { name, layer: this.layer },


### PR DESCRIPTION
Add pane support to l-tile-layer-wms so that when the element is a child of pane leaflet can add the tile images under the right pane div.