### PR TITLE
Only disable zoom-control is explicitly requested

### DIFF
--- a/src/l-map.js
+++ b/src/l-map.js
@@ -54,7 +54,12 @@ class LMap extends HTMLElement {
   }
 
   connectedCallback() {
-    this.map = L.map(this, { zoomControl: this.hasAttribute("zoom-control") });
+    let opts = {}
+    if (this.hasAttribute("zoom-control")) {
+        // TODO: decide the best ergonomics for this.
+        opts.zoomControl = this.getAttribute("zoom-control") !== "off"
+    }
+    this.map = L.map(this, opts);
 
     // Allow listeners to know when the map is "ready"
     this.map.whenReady(() => {


### PR DESCRIPTION

## Bug fix

Leaflet HTML should replicate Leaflet JS ergonomics. Zoom controls should be default on and disabled with an attribute.

- `<l-map>` without explicitly setting `zoom-control` attribute should behave like LeafletJS.
- `<l-map zoom-control="off">` disables the controls in this solution 