### PR TITLE
Resolve issue 54 control layers

### DIFF
--- a/src/l-map.js
+++ b/src/l-map.js
@@ -86,10 +86,19 @@ class LMap extends HTMLElement {
       this.map.locate(parse(schema, this));
     }
 
+    const layerConnectedHandlers = {
+      "l-control-layers": (layer, map) => layer.addTo(map),
+      "default": (layer, map) => map.addLayer(layer),
+    };
+    
     this.addEventListener(layerConnected, (ev) => {
-      const layer = ev.detail.layer;
-      this.map.addLayer(layer);
+      const { layer } = ev.detail;
+      const target = ev.target.localName ;
+      
+      const layerConnectedHandler = layerConnectedHandlers[target] || layerConnectedHandlers["default"];
+      layerConnectedHandler(layer, this.map);
     });
+    
 
     this.addEventListener(layerRemoved, (ev) => {
       if (this.map !== null) {


### PR DESCRIPTION
This resolves [issue#54](https://github.com/andrewgryan/leaflet-html/issues/54).

The bug pertains to the leaflet addLayer method, which doesn't work for control layers, see: https://github.com/search?q=repo%3ALeaflet%2FLeaflet%20%22not%20a%20layer%22&type=code

This fix is based on the syntactic usage of control layers in [leaflet reference docs for the control-layer](https://leafletjs.com/reference.html#control-layers).

See screenshot below to visualise fix:

![image](https://github.com/user-attachments/assets/981f49bd-3715-415a-b612-97caee11582b)

Comments welcomed.