### PR TITLE
Circles, polygones and friends should be able to be removed

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { Circle, LatLng, Polygon, Polyline, Rectangle } from "leaflet";
+import { Circle, LatLng, Polygon, Polyline, Rectangle, stamp } from "leaflet";
 import { camelToKebab } from "./util.js";
 import { htmlAttribute, parse } from "./parse.js";
 import { layerConnected, tooltipConnected } from "./events.js";
@@ -248,6 +248,7 @@ const generator = (method, methodName) => {
       const args = positional(this, methodName);
       const options = settings(this, methodName);
       this.layer = method(...args, options);
+      this.setAttribute("leaflet-id", stamp(this.layer));
       const event = new CustomEvent(layerConnected, {
         cancelable: true,
         bubbles: true,


### PR DESCRIPTION
Hello,

I noticed that removing a `l-circle` HTML tag from a document didn't remove it from the map. After some debugging (I am neither acquainted with leaflet nor javascript) I caught that it was a restriction in the MutationObserver object in `src/l-layer-group.js`, ignoring every element without the `leaflet-id` attribute.

With this PR I add the required attribute in the generator.js file, thus extending the graceful removal of l-marker to l-circle, l-polyline, etc.