### PR TITLE
Remove any child node with the leaflet-id attribute

### DIFF
--- a/src/l-layer-group.js
+++ b/src/l-layer-group.js
@@ -3,6 +3,14 @@ import { layerGroup } from "leaflet";
 import { layerConnected } from "./events.js";
 import LLayer from "./l-layer.js";
 
+function _removeNode(group, node) {
+  const leafletId = node.getAttribute("leaflet-id");
+  const layer = group.getLayer(parseInt(leafletId));
+  if (typeof layer !== "undefined") {
+    group.removeLayer(layer);
+  }
+}
+
 class LLayerGroup extends LLayer {
   constructor() {
     super();
@@ -33,13 +41,10 @@ class LLayerGroup extends LLayer {
       mutations.forEach((mutation) => {
         mutation.removedNodes.forEach((node) => {
           if (node instanceof HTMLElement) {
-            const leafletId = node.getAttribute("leaflet-id");
-            if (leafletId !== null) {
-              const layer = group.getLayer(parseInt(leafletId));
-              if (typeof layer !== "undefined") {
-                group.removeLayer(layer);
-              }
-            }
+            node.querySelectorAll("[leaflet-id]").forEach((child) => {
+              _removeNode(group, child);
+            });
+            _removeNode(group, node);
           }
         });
       });


### PR DESCRIPTION
Hello,

This is an update for my previous PR #69.
Instead of looking only for the top-most node in the mutation observer I use `querySelectorAll()` to check for any child node containing the magic attribute.

This is motivated by my usage of leaflet-html where I use an intermediate `div` to group some elements inside of more generic `l-layer-group`, something like this :

```html
<l-layer-group id="circles-only">
  <div id="circles-for-user-foobar">
    <l-circle ...></l-circle>
    <l-circle ...></l-circle>
    <l-circle ...></l-circle>
  </div>
</l-layer-group>
```

With this patch I can now remove the div with id `circles-for-user-foobar` and the mutation observer correctly removes all the sub circles from leaflet.